### PR TITLE
1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Contributions to the Devopology Test Engine are both welcomed and appreciated.
 
 ## Common Annotations
 
-
 | Annotation                      | Scope            | Required | Static | Examples                                                                                              |
 |---------------------------------|------------------|----------|--------|-------------------------------------------------------------------------------------------------------|
 | `@TestEngine.ParameterSupplier` | field or method  | yes      | yes    | `public static Collection<String> PARAMETERS;` <br/> `public static Collection<String> parameters();` |
@@ -49,6 +48,14 @@ Contributions to the Devopology Test Engine are both welcomed and appreciated.
 **NOTES**
 
 - Methods are sorted / executed in alphabetical order based on a `String.compareTo` comparison of method names
+
+## Additional Annotations
+
+
+| Annotation              | Scope | Required | Usage                                                             |
+|-------------------------|-------|----------|-------------------------------------------------------------------|
+| `@TestEngine.BaseClass` | class | no       | Marks a test class as being a base class (skips direct execution) |
+
 
 # State Machine Flow
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.devopology</groupId>
     <artifactId>test-engine</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <name>Devopology - Test Engine</name>
 
     <properties>

--- a/src/main/java/org/devopology/test/engine/api/TestEngine.java
+++ b/src/main/java/org/devopology/test/engine/api/TestEngine.java
@@ -79,6 +79,15 @@ public @interface TestEngine {
 
     }
 
+    @Target({ ElementType.ANNOTATION_TYPE, ElementType.TYPE })
+    @Retention(RetentionPolicy.RUNTIME)
+    /**
+     * Annotation to mark a test class as a base class (don't execute)
+     */
+    @interface BaseClass {
+
+    }
+
     @Target({ ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE })
     @Retention(RetentionPolicy.RUNTIME)
     /**

--- a/src/main/java/org/devopology/test/engine/support/TestEngineDiscoverySelectorResolver.java
+++ b/src/main/java/org/devopology/test/engine/support/TestEngineDiscoverySelectorResolver.java
@@ -92,20 +92,6 @@ public class TestEngineDiscoverySelectorResolver {
         // For each test method that was selected, add the test class and method
         resolveMethodSelector(engineDiscoveryRequest, testClassToMethodMap);
 
-        /*
-        // Sort the test methods by name (Test classes are already sorted by name)
-        for (Map.Entry<Class<?>, Collection<Method> mapEntry : testClassToMethodMap.entrySet()) {
-            Collections.sort(mapEntry.getValue(), Comparator.comparing(Method::getName));
-        }
-
-        for (Class<?> testClass : testClassToMethodMap.keySet()) {
-            List<Method> testMethodList = testClassToMethodMap.get(testClass);
-            for (Method method : testMethodList) {
-                LOGGER.trace("test class [%s] @TestEngine.Test method [%s]", testClass.getName(), method.getName());
-            }
-        }
-        */
-
         processSelectors(engineDescriptor, testClassToMethodMap);
     }
 

--- a/src/main/java/org/devopology/test/engine/support/TestEngineDiscoverySelectorResolver.java
+++ b/src/main/java/org/devopology/test/engine/support/TestEngineDiscoverySelectorResolver.java
@@ -55,7 +55,7 @@ public class TestEngineDiscoverySelectorResolver {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestEngineDiscoverySelectorResolver.class);
 
     /**
-     * Predicate to determine if a class is a test class (has @Test methods)
+     * Predicate to determine if a class is a test class (has @TestEngine.Test methods)
      */
     private static final Predicate<Class<?>> IS_TEST_CLASS = clazz -> {
         int modifiers = clazz.getModifiers();
@@ -69,7 +69,7 @@ public class TestEngineDiscoverySelectorResolver {
             method -> TestEngineUtils.getTestMethods(method.getDeclaringClass()).contains(method);
 
     /**
-     * Method to resolve tests, adding them to the EngineDescriptor
+     * Method to resolve test classes / methods, adding them to the EngineDescriptor
      *
      * @param engineDiscoveryRequest
      * @param engineDescriptor
@@ -195,6 +195,11 @@ public class TestEngineDiscoverySelectorResolver {
         try {
             for (Class<?> testClass : testClassToMethodMap.keySet()) {
                 LOGGER.trace("test class [%s]", testClass.getName());
+
+                if (TestEngineUtils.isBaseClass(testClass)) {
+                    LOGGER.trace("test class [%s] is a base class not meant for execution", testClass.getName());
+                    continue;
+                }
 
                 if (TestEngineUtils.isDisabled(testClass)) {
                     LOGGER.trace("test class [%s] is disabled", testClass.getName());

--- a/src/main/java/org/devopology/test/engine/support/TestEngineDiscoverySelectorResolver.java
+++ b/src/main/java/org/devopology/test/engine/support/TestEngineDiscoverySelectorResolver.java
@@ -249,7 +249,7 @@ public class TestEngineDiscoverySelectorResolver {
                 LOGGER.trace("test class parameter count [%d]", testParameters.size());
                 LOGGER.trace("test class @TestEngine.ParameterInject field [%s]", parameterInjectField.getName());
 
-                if (testParameters.size() == 0) {
+                if (testParameters.isEmpty()) {
                     throw new TestClassConfigurationException(
                             String.format(
                                     "Test class [%s] @TestEngine.ParameterSupplier collection is empty",

--- a/src/main/java/org/devopology/test/engine/support/TestEngineUtils.java
+++ b/src/main/java/org/devopology/test/engine/support/TestEngineUtils.java
@@ -38,8 +38,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**

--- a/src/main/java/org/devopology/test/engine/support/TestEngineUtils.java
+++ b/src/main/java/org/devopology/test/engine/support/TestEngineUtils.java
@@ -20,7 +20,6 @@ import org.devopology.test.engine.api.Metadata;
 import org.devopology.test.engine.api.TestEngine;
 import org.devopology.test.engine.support.logger.Logger;
 import org.devopology.test.engine.support.logger.LoggerFactory;
-import org.devopology.test.engine.support.util.Switch;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.TestDescriptor;
 import org.junit.platform.launcher.TestPlan;
@@ -37,7 +36,6 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 
 /**
@@ -88,21 +86,21 @@ public final class TestEngineUtils {
     /**
      * Method to get a Collection of Fields for a Class and super Classes
      *
-     * @param baseClass
+     * @param clazz
      * @return
      */
     private static Collection<Field> getAllFields(
-            Class<?> baseClass,
+            Class<?> clazz,
             Class<? extends Annotation> annotation,
             Scope scope) {
         LOGGER.trace(
                 "getAllFields(%s, %s, %s)",
-                baseClass.getName(),
+                clazz.getName(),
                 annotation.getName(),
                 scope);
 
         Map<String, Field> fieldMap = new HashMap<>();
-        resolveFields(baseClass, annotation, scope, fieldMap);
+        resolveFields(clazz, annotation, scope, fieldMap);
         List<Field> fieldList = new LinkedList<>(fieldMap.values());
         fieldList.sort(Comparator.comparing(Field::getName));
 
@@ -157,25 +155,25 @@ public final class TestEngineUtils {
     /**
      * Method to get a Collection of all methods from a Class and super Classes
      *
-     * @param baseClass
+     * @param clazz
      * @return
      */
     private static Collection<Method> getAllMethods(
-            Class<?> baseClass,
+            Class<?> clazz,
             Class<? extends Annotation> annotation,
             Scope scope,
             Class<?> returnType,
             int parameterCount) {
         LOGGER.trace(
                 "getAllMethods(%s, %s, %s, %s, %d)",
-                baseClass.getName(),
+                clazz.getName(),
                 annotation.getName(),
                 scope,
                 returnType.getName(),
                 parameterCount);
 
         Map<String, Method> methodMap = new HashMap<>();
-        resolveMethods(baseClass, annotation, scope, returnType, parameterCount, methodMap);
+        resolveMethods(clazz, annotation, scope, returnType, parameterCount, methodMap);
         List<Method> methodList = new LinkedList<>(methodMap.values());
         methodList.sort(Comparator.comparing(Method::getName));
 
@@ -265,7 +263,7 @@ public final class TestEngineUtils {
                             Void.class,
                             0);
 
-            beforeClassMethodCache.put(clazz, methods);
+            beforeClassMethodCache.put(clazz, Collections.unmodifiableCollection(methods));
 
             return methods;
         }
@@ -291,7 +289,7 @@ public final class TestEngineUtils {
                             TestEngine.ParameterInject.class,
                             Scope.NON_STATIC);
 
-            parameterInjectFieldCache.put(clazz, fields);
+            parameterInjectFieldCache.put(clazz, Collections.unmodifiableCollection(fields));
 
             return fields;
         }
@@ -322,7 +320,7 @@ public final class TestEngineUtils {
             }
         }
 
-        parameterSupplierFieldsCache.put(clazz, parameterSupplierFields);
+        parameterSupplierFieldsCache.put(clazz, Collections.unmodifiableCollection(parameterSupplierFields));
 
         return parameterSupplierFields;
     }
@@ -349,7 +347,7 @@ public final class TestEngineUtils {
                             Collection.class,
                             0);
 
-            parameterSupplierMethodsCache.put(clazz, methods);
+            parameterSupplierMethodsCache.put(clazz, Collections.unmodifiableCollection(methods));
 
             return methods;
         }
@@ -375,7 +373,7 @@ public final class TestEngineUtils {
                             Void.class,
                             0);
 
-            beforeAllMethodCache.put(clazz, methods);
+            beforeAllMethodCache.put(clazz, Collections.unmodifiableCollection(methods));
 
             return methods;
         }
@@ -401,7 +399,7 @@ public final class TestEngineUtils {
                             Void.class,
                             0);
 
-            beforeEachMethodCache.put(clazz, methods);
+            beforeEachMethodCache.put(clazz, Collections.unmodifiableCollection(methods));
 
             return methods;
         }
@@ -429,7 +427,7 @@ public final class TestEngineUtils {
                             Void.class,
                             0);
 
-            testMethodCache.put(clazz, methods);
+            testMethodCache.put(clazz, Collections.unmodifiableCollection(methods));
 
             return methods;
         }
@@ -455,9 +453,7 @@ public final class TestEngineUtils {
                             Void.class,
                             0);
 
-            testMethodCache.put(clazz, methods);
-
-            afterEachMethodCache.put(clazz, methods);
+            afterEachMethodCache.put(clazz, Collections.unmodifiableCollection(methods));
 
             return methods;
         }
@@ -483,7 +479,7 @@ public final class TestEngineUtils {
                             Void.class,
                             0);
 
-            afterAllMethodCache.put(clazz, methods);
+            afterAllMethodCache.put(clazz, Collections.unmodifiableCollection(methods));
 
             return methods;
         }
@@ -509,7 +505,7 @@ public final class TestEngineUtils {
                             Void.class,
                             0);
 
-            afterClassMethodCache.put(clazz, methods);
+            afterClassMethodCache.put(clazz, Collections.unmodifiableCollection(methods));
 
             return methods;
         }

--- a/src/main/java/org/devopology/test/engine/support/TestEngineUtils.java
+++ b/src/main/java/org/devopology/test/engine/support/TestEngineUtils.java
@@ -215,13 +215,11 @@ public final class TestEngineUtils {
                 })
                 .filter(method -> {
                     int modifiers = method.getModifiers();
-                    switch (scope) {
-                        case STATIC: {
-                            return Modifier.isStatic(modifiers);
-                        }
-                        default: {
-                            return !Modifier.isStatic(modifiers);
-                        }
+                    if (scope == Scope.STATIC) {
+                        return Modifier.isStatic(modifiers);
+                    }
+                    else {
+                        return !Modifier.isStatic(modifiers);
                     }
                 })
                 .filter(method -> method.getParameterCount() == parameterCount)
@@ -620,15 +618,11 @@ public final class TestEngineUtils {
             return "null";
         }
 
-        String displayName;
+        String displayName = null;
 
-        AtomicReference<String> result = new AtomicReference<>();
-
-        Switch.switchType(
-                object,
-                Switch.switchCase(Metadata.class, metadata -> result.set(metadata.getDisplayName())));
-
-        displayName = result.get();
+        if (object instanceof Metadata) {
+            displayName = ((Metadata) object).getDisplayName();
+        }
 
         if (displayName == null) {
             displayName = object.toString();

--- a/src/main/java/org/devopology/test/engine/support/TestEngineUtils.java
+++ b/src/main/java/org/devopology/test/engine/support/TestEngineUtils.java
@@ -521,6 +521,16 @@ public final class TestEngineUtils {
     }
 
     /**
+     * Method to get whether a test class is a base class
+     *
+     * @param clazz
+     * @return
+     */
+    public static boolean isBaseClass(Class<?> clazz) {
+        return clazz.isAnnotationPresent(TestEngine.BaseClass.class);
+    }
+
+    /**
      * Method to get whether a test class is disabled
      *
      * @param clazz

--- a/src/main/java/org/devopology/test/engine/support/TestEngineUtils.java
+++ b/src/main/java/org/devopology/test/engine/support/TestEngineUtils.java
@@ -136,13 +136,10 @@ public final class TestEngineUtils {
                 })
                 .filter(field -> {
                     int modifiers = field.getModifiers();
-                    switch (scope) {
-                        case STATIC: {
-                            return Modifier.isStatic(modifiers);
-                        }
-                        default: {
-                            return !Modifier.isStatic(modifiers);
-                        }
+                    if (scope == Scope.STATIC) {
+                        return Modifier.isStatic(modifiers);
+                    } else {
+                        return !Modifier.isStatic(modifiers);
                     }
                 }).forEach(field -> {
                     if (fieldMap.putIfAbsent(field.getName(), field) == null) {

--- a/src/main/java/org/devopology/test/engine/support/logger/impl/LoggerImpl.java
+++ b/src/main/java/org/devopology/test/engine/support/logger/impl/LoggerImpl.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 /**
  * Class to implement logger
  */
+@SuppressWarnings("PMD.GodClass")
 public class LoggerImpl implements Logger {
 
     private static final SimpleDateFormat SIMPLE_DATE_FORMAT =

--- a/src/test/java/org/devopology/test/engine/test/example/NamedTest.java
+++ b/src/test/java/org/devopology/test/engine/test/example/NamedTest.java
@@ -42,7 +42,7 @@ public class NamedTest {
         System.out.println("test2(" + parameter + ")");
     }
 
-    @TestEngine.Test
+    @TestEngine.AfterAll
     public void afterAll() {
         System.out.println("afterAll()");
     }

--- a/src/test/java/org/devopology/test/engine/test/example/inheritance/BaseTest.java
+++ b/src/test/java/org/devopology/test/engine/test/example/inheritance/BaseTest.java
@@ -6,7 +6,8 @@ import org.devopology.test.engine.api.TestEngine;
 import java.util.ArrayList;
 import java.util.Collection;
 
-public abstract class BaseTest {
+@TestEngine.BaseClass
+public class BaseTest {
 
     @TestEngine.ParameterInject
     protected int parameter;

--- a/src/test/java/org/devopology/test/engine/test/example/inheritance/BaseTest.java
+++ b/src/test/java/org/devopology/test/engine/test/example/inheritance/BaseTest.java
@@ -23,6 +23,11 @@ public abstract class BaseTest {
     }
 
     @TestEngine.BeforeClass
+    protected static void _beforeClass() {
+        System.out.println("_beforeClass()");
+    }
+
+    @TestEngine.BeforeClass
     protected static void beforeClass() {
         System.out.println("beforeClass()");
     }
@@ -45,5 +50,10 @@ public abstract class BaseTest {
     @TestEngine.AfterClass
     protected static void afterClass() {
         System.out.println("afterClass()");
+    }
+
+    @TestEngine.AfterClass
+    protected static void afterClass_() {
+        System.out.println("afterClass_()");
     }
 }


### PR DESCRIPTION
Added marker annotation `TestEngine.BaseClass` for base test classes that shouldn't be executed directly
Fixed `TestEngineUtils`

Fixed benign, but invalid code when resolving `TestEngine.AfterAll` methods.